### PR TITLE
Remove the automation instructions from the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,3 @@
----
-labels: pending-review
-assignees:
-  - jayasanka-sack
-  - akshika47
-  - anjula-sack
-  - Piumal1999
----
-
-
 To suggest a change to the [Handbook](https://handbook.sefglobal.org/), please review the [Handbook Guidlines](https://handbook.sefglobal.org/organisation/handbook/usage#handbook-guidelines) section.
 
 <!-- please list any related epics, issues or PRs here. 


### PR DESCRIPTION
To suggest a change to the [Handbook](https://handbook.sefglobal.org/), please review the [Handbook Guidlines](https://handbook.sefglobal.org/organisation/handbook/usage#handbook-guidelines) section.

<!-- please list any related epics, issues or PRs here. 
	This field is optional, check this: https://handbook.sefglobal.org/organisation/handbook/usage#how-to-change-or-define-a-process -->


### Please provide a brief explanation for this change:
<!-- (If there's a due date for merging this PR, be sure to include it here.) -->
The automation instruction section of the PR template seems not working. Even though it has been mentioned it works for PRs too, I assume they support automation only for issue templates. Therefore removing the section.

**Preview Link:**
N/A

### Please indicate the types of revisions being suggested for the Handbook (please check all that apply):

* [ ] Small improvement (typos, clarifications, etc.)
* [ ] Adding a new section
* [ ] Modifying existing section
* [ ] Documenting a new process
* [ ] Adding a new page or directory
* [x] Other

### Author Checklist

* [x] Provided a concise title for the PR
* [x] Provided a brief explanation for this change (Say why not just what)
  * (Attach screenshots, Slack conversations, etc. as necessary)
* [x] Indicated the types of changes included in this PR
* [x] Verified that no confidential data is in this PR
* [ ] Posted an update in [#handbook](https://sefheadquarters.slack.com/archives/C0376JVK2HF) channel
* [ ] If the changes affect team members, or warrant an announcement in another way, please consider posting an update in [#general](https://sefheadquarters.slack.com/archives/CJ89Y7JAV) channel


<!-- This PR template is inspired by Gitlab -->