### PR TITLE
Add new "Team Responsibilities" page

### DIFF
--- a/docs/organisation/engineering-team.md
+++ b/docs/organisation/engineering-team.md
@@ -185,6 +185,32 @@ The hierarchy of badges and the requirements are as follows:
   - Has level 4 badge
   - Will be added to the engineering team as a software engineer
 
+## Team Responsibilities
+
+Since joining the engineering team takes a considerable amount of effort and going through an evaluation process, continuing to be a part of the team would also require the same effort. Being part of the team is a rare opportunity and it is our responsibility as management to determine whether the efforts you make meet our expectations. The following points will be used to ascertain such efforts:
+
+- Have you been consistently participating in the standups?  
+At least 8 days of participation per a time period of 3 months is considered mandatory
+- Did you keep the team updated on the days on which you were unable to participate in a standup?  
+Stating the reason for absence is not mandatory, yet keeping the team updated on the status of your recent tasks is appreciated.
+- Have you led or contributed to a project feature recently?  
+Proactively taking part and contributing to new features as well as leading them is a major responsibility of being part of the engineering team.
+- Were you able to meet the deadlines?  
+Even though we are feature based, it is expected from a team member to complete the tasks on time. If certain circumstances are hindering your performance, please be kind enough to update the team. Therefore the task can be assigned to another team member or an extension can be granted.
+
+
+Although it is not expected from you to strictly adhere to the following points, consider them as expectations of a responsible team member:
+
+- Following [best practices](https://github.com/miniskynet/sef-site/blob/master/CONTRIBUTING.md) when contributing
+- Keeping the team updated if you are taking a leave
+- Proactively contributing instead of waiting to be assigned to a task
+- Taking ownership when it comes to your tasks and meeting deadlines
+- Helping out your fellow colleagues 
+- Communication -  
+  - Keep the team updated on what you are working on, either through hive posts or slack messages
+  - If you are facing blockers or any issues, keep the team updated
+  - Keep discussions public, since every member can chip in their thoughts
+
 
 ## Meeting Links
 

--- a/docs/organisation/engineering-team.md
+++ b/docs/organisation/engineering-team.md
@@ -211,7 +211,6 @@ Although it is not expected from you to strictly adhere to the following points,
   - If you are facing blockers or any issues, keep the team updated
   - Keep discussions public, since every member can chip in their thoughts
 
-
 ## Meeting Links
 
 - General Meetings (Bi-weekly Sun IST 7pm) - https://meet.google.com/hva-ugdf-mrb


### PR DESCRIPTION
### Purpose:
The purpose of this PR is to fix #21 

<!-- please list any related epics, issues or PRs here. 
	This field is optional, check this: https://handbook.sefglobal.org/organisation/handbook/usage#how-to-change-or-define-a-process -->
### Related to:
Engineering team page

### Please provide a brief explanation for this change:
<!-- (If there's a due date for merging this PR, be sure to include it here.) -->
This PR adds a new section called "Team Responsibilities" to the engineering team page

**Preview Link:**
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. ex: https://pr-11-sef-handbook.surge.sh -->
<!--- Feel free to modify the link with the exact path -->
https://pr-22-sef-handbook.surge.sh/

### Please indicate the types of revisions being suggested for the Handbook (please check all that apply):

* [ ] Small improvement (typos, clarifications, etc.)
* [x] Adding a new section
* [ ] Modifying existing section
* [ ] Documenting a new process
* [ ] Adding a new page or directory
* [ ] Other

### Author Checklist

* [x] Provided a concise title for the PR
* [x] Provided a brief explanation for this change (Say why not just what)
  * (Attach screenshots, Slack conversations, etc. as necessary)
* [x] Indicated the types of changes included in this PR
* [x] Verified that no confidential data is in this PR
* [ ] Posted an update in [#handbook](https://sefheadquarters.slack.com/archives/C0376JVK2HF) channel
* [ ] If the changes affect team members, or warrant an announcement in another way, please consider posting an update in [#general](https://sefheadquarters.slack.com/archives/CJ89Y7JAV) channel


<!-- This PR template is inspired by Gitlab -->